### PR TITLE
fix(pi): stop stale extension ctx from spamming the console

### DIFF
--- a/src/pi/ui.ts
+++ b/src/pi/ui.ts
@@ -3,7 +3,7 @@
 import type { ExtensionContext, ThemeColor } from "@earendil-works/pi-coding-agent" with {
   "resolution-mode": "import",
 };
-import { logExtensionError } from "../shared/errors.js";
+import { isStaleContextError, logExtensionError } from "../shared/errors.js";
 import { describeRanges } from "../shared/format.js";
 import { basename } from "node:path";
 import { EXT_CONFIG_NAME, readPiConfigStatusDisplay } from "../shared/config.js";
@@ -47,7 +47,9 @@ function getActiveUiContext(ctx: ExtensionContext | undefined): ActiveUiContext 
     if (!ctx.hasUI) return undefined;
     return { cwd: ctx.cwd, ui: ctx.ui };
   } catch (error) {
-    logExtensionError("read active Pi UI context", error);
+    // Stale ctx (post reload/session swap) is an expected signal, not a fault;
+    // logging it would spam on every UI refresh. Surface only real failures.
+    if (!isStaleContextError(error)) logExtensionError("read active Pi UI context", error);
     return undefined;
   }
 }

--- a/src/shared/errors.ts
+++ b/src/shared/errors.ts
@@ -5,6 +5,10 @@ export function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+export function isStaleContextError(error: unknown): boolean {
+  return errorMessage(error).includes("stale after session replacement or reload");
+}
+
 export function toError(error: unknown, prefix?: string): Error {
   if (error instanceof Error) {
     if (!prefix) return error;

--- a/test/shared.test.ts
+++ b/test/shared.test.ts
@@ -128,7 +128,7 @@ void test("clears stale editor selection state", () => {
   assert.equal(runtime.attachState, "idle");
 });
 
-void test("logs stale extension ctx while updating selection UI", () => {
+void test("ignores stale extension ctx while updating selection UI", () => {
   const runtime = createRuntime();
   runtime.ctx = {
     get hasUI(): boolean {
@@ -141,8 +141,7 @@ void test("logs stale extension ctx while updating selection UI", () => {
   });
   assert.equal(runtime.latestSelection, snapshot);
   assert.equal(runtime.attachState, "pending");
-  assert.equal(errors.length, 1);
-  assert.match(errors[0] ?? "", /read active Pi UI context: This extension ctx is stale/);
+  assert.equal(errors.length, 0);
 });
 
 void test("logs non-stale extension ctx errors while updating selection UI", () => {


### PR DESCRIPTION
## Summary

- `getActiveUiContext` logged the *expected* stale-ctx signal, turning a benign lifecycle event into repeated full-stack `console.error` output that floods the terminal.
- A `ctx` captured by a long-lived IDE connection (`onSelectionChanged` → `setLatestSelection`) or the Zed poll fiber keeps calling `updateIdeUi` after a session replacement (`newSession`/`fork`/`switchSession`) or `reload`. Every getter on the replaced ctx throws `assertActive`, so each cursor move or poll tick reprinted the stack.
- `ui.ts` already advertises helpers that "tolerate stale pi extension contexts", so the noisy log path contradicted the file’s own contract.

## Change

- Add `isStaleContextError` to `src/shared/errors.ts` (matches the pi runner’s stale sentinel message).
- In `getActiveUiContext`, skip logging when the caught error is the stale-ctx signal; genuinely unexpected UI-context failures are still logged. The graceful `return undefined` behaviour is unchanged, so UI updates stay a safe no-op until the next fresh ctx.
- Update the existing `shared.test.ts` case (stale ctx now asserts zero logs); the non-stale case still asserts the error is logged.

## Why fix at the sink, not the source

The deeper root cause is that a stale `ctx` reaches `updateIdeUi` at all: zombie callbacks from an orphaned runtime (IDE connection listeners / Zed poll fiber) briefly outlive their session. Fixing *that* means tearing those down on invalidate (unregister listeners / interrupt the fiber), which is a larger change across the connection and Zed lifecycle.

I intentionally scoped this PR to the sink because that matches the established design: #26 chose to *tolerate* stale callbacks gracefully rather than prevent them, and a swallow-guard at the sink is sound defense-in-depth since async teardown always races. The only defect against that design was logging an expected signal.

Happy to follow up with the source-side teardown (stop the zombie callbacks) if needed.

## Validation

- [x] `bunx tsc -p tsconfig.json --noEmit` (typecheck)
- [x] `bunx eslint` on changed files
- [x] `bunx prettier --check` on changed files
- [x] `node --test dist/test/*.test.js` — 123 pass, 0 fail
- [x] Regression confirmed: the updated stale-ctx test fails on `main` and passes with this change.