### PR TITLE
feat: add contextPlacement option to control editor context reminder placement

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/balaenis/pi-x-ide/refs/heads/main/schemas/config.json",
   "fixPrompt": "Analyze the errors and warnings at the following location, and try to fix them:\n{DIAGNOSTIC}",
   "status_display": "widget",
+  "contextPlacement": "prepend",
   "env": {
     "PI_X_IDE_AUTO_INSTALL": "1",
     "PI_X_IDE_ATTACH_SHORTCUT": "ctrl+alt+k"

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -17,6 +17,7 @@ Pi-side variables can be set as real environment variables **or** in config
   "$schema": "https://raw.githubusercontent.com/balaenis/pi-x-ide/refs/heads/main/schemas/config.json",
   "fixPrompt": "Analyze the errors and warnings at the following location, and try to fix them:\n{DIAGNOSTIC}",
   "status_display": "widget",
+  "contextPlacement": "prepend",
   "env": {
     "PI_X_IDE_AUTO_INSTALL": "1",
     "PI_X_IDE_ATTACH_SHORTCUT": "ctrl+alt+k"
@@ -92,10 +93,11 @@ custom command. See
 
 <a id="top-level-options"></a>
 
-| Option           | Default                                                                                         | Description                                                                                                                                                                                                                                  |
-| ---------------- | ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `fixPrompt`      | `Analyze the errors and warnings at the following location, and try to fix them:\n{DIAGNOSTIC}` | Custom prompt prefix when requesting a fix for IDE diagnostics. Use `{DIAGNOSTIC}` as a placeholder for the diagnostic context. If the placeholder is omitted, the diagnostic context is appended after your prompt.                         |
-| `status_display` | `widget`                                                                                        | Where to show IDE connection status in the Pi TUI. Default `widget` (above-editor); `statusline` uses the footer status line. Only one placement is active at a time. Project config overrides global. Set as `Display` via `/ide settings`. |
+| Option             | Default                                                                                         | Description                                                                                                                                                                                                                                  |
+| ------------------ | ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `fixPrompt`        | `Analyze the errors and warnings at the following location, and try to fix them:\n{DIAGNOSTIC}` | Custom prompt prefix when requesting a fix for IDE diagnostics. Use `{DIAGNOSTIC}` as a placeholder for the diagnostic context. If the placeholder is omitted, the diagnostic context is appended after your prompt.                         |
+| `status_display`   | `widget`                                                                                        | Where to show IDE connection status in the Pi TUI. Default `widget` (above-editor); `statusline` uses the footer status line. Only one placement is active at a time. Project config overrides global. Set as `Display` via `/ide settings`. |
+| `contextPlacement` | `prepend`                                                                                       | Where to place the editor context `<system-reminder>` relative to your prompt text. Default `prepend` puts it before your prompt; `append` puts it after so your prompt stays first in transcript views. Project config overrides global.    |
 
 The `fixPrompt` controls the prompt used by the VS Code **Pi: Fix it** Quick Fix
 action. See [Install the VS Code extension](../how-to/install-vscode.md#diagnostic-quick-fix).

--- a/docs/zh-CN/reference/configuration.md
+++ b/docs/zh-CN/reference/configuration.md
@@ -14,6 +14,7 @@ Pi 侧变量可设为真实环境变量 **或** 写入 config 的 `env`。真实
   "$schema": "https://raw.githubusercontent.com/balaenis/pi-x-ide/refs/heads/main/schemas/config.json",
   "fixPrompt": "Analyze the errors and warnings at the following location, and try to fix them:\n{DIAGNOSTIC}",
   "status_display": "widget",
+  "contextPlacement": "prepend",
   "env": {
     "PI_X_IDE_AUTO_INSTALL": "1",
     "PI_X_IDE_ATTACH_SHORTCUT": "ctrl+alt+k"
@@ -86,9 +87,10 @@ require("pi_x_ide").setup({
 
 <a id="顶层选项"></a>
 
-| 选项             | 默认值                                                                                          | 说明                                                                                                                                                                                    |
-| ---------------- | ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `fixPrompt`      | `Analyze the errors and warnings at the following location, and try to fix them:\n{DIAGNOSTIC}` | 请求修复 IDE 诊断信息时的自定义 prompt 前缀。使用 `{DIAGNOSTIC}` 作为诊断上下文的占位符。如果未包含占位符，诊断上下文会拼接在你的 prompt 之后。                                         |
-| `status_display` | `widget`                                                                                        | 在 Pi TUI 中显示 IDE 连接状态的位置。默认 `widget`（编辑器上方）；`statusline` 使用页脚状态行。同一时间只启用一种显示方式。项目配置覆盖全局。可在 `/ide settings` 中以 `Display` 设置。 |
+| 选项               | 默认值                                                                                          | 说明                                                                                                                                                                                    |
+| ------------------ | ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `fixPrompt`        | `Analyze the errors and warnings at the following location, and try to fix them:\n{DIAGNOSTIC}` | 请求修复 IDE 诊断信息时的自定义 prompt 前缀。使用 `{DIAGNOSTIC}` 作为诊断上下文的占位符。如果未包含占位符，诊断上下文会拼接在你的 prompt 之后。                                         |
+| `status_display`   | `widget`                                                                                        | 在 Pi TUI 中显示 IDE 连接状态的位置。默认 `widget`（编辑器上方）；`statusline` 使用页脚状态行。同一时间只启用一种显示方式。项目配置覆盖全局。可在 `/ide settings` 中以 `Display` 设置。 |
+| `contextPlacement` | `prepend`                                                                                       | 编辑器上下文 `<system-reminder>` 相对于你提示文本的位置。默认 `prepend` 将其放在提示之前；`append` 将其放在提示之后，使你的提示在会话树等转录视图中保持在前。项目配置覆盖全局。         |
 
 `fixPrompt` 控制 VS Code **Pi: Fix it** Quick Fix 使用的 prompt。见 [安装 VS Code 扩展](../how-to/install-vscode.md#诊断-quick-fix)。

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -20,6 +20,15 @@
         "statusline"
       ]
     },
+    "contextPlacement": {
+      "type": "string",
+      "description": "Where to place the editor context system-reminder relative to your prompt. Use \"prepend\" to put it before your prompt text (default), or \"append\" to put it after so your prompt stays first in transcript views.",
+      "default": "prepend",
+      "enum": [
+        "prepend",
+        "append"
+      ]
+    },
     "env": {
       "type": "object",
       "description": "Pi-side environment variables. Real environment variables override these values.",
@@ -66,6 +75,7 @@
     {
       "fixPrompt": "Analyze the errors and warnings at the following location, and try to fix them:\n{DIAGNOSTIC}",
       "status_display": "widget",
+      "contextPlacement": "prepend",
       "env": {
         "PI_X_IDE_AUTO_INSTALL": "0",
         "PI_X_IDE_ATTACH_SHORTCUT": "ctrl+alt+k",

--- a/src/pi/context.ts
+++ b/src/pi/context.ts
@@ -4,6 +4,8 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent" with {
   "resolution-mode": "import",
 };
 import { formatEditorContext, SYSTEM_REMINDER_TAG, SELECTED_CONTEXT_MARKER } from "../shared/format.js";
+import { readPiConfigContextPlacement } from "../shared/config.js";
+import { DEFAULT_CONTEXT_PLACEMENT, type ContextPlacement } from "../shared/config-options.js";
 import { DIAGNOSTIC_CONTEXT_MARKER } from "./diagnostics.js";
 import { runPiBoundary } from "./safety.js";
 import type { PiIdeRuntime } from "./state.js";
@@ -44,7 +46,8 @@ export function registerContextHandlers(pi: ExtensionAPI, runtime: PiIdeRuntime)
         }
 
         const text = `${formatEditorContext(runtime.turnSelection)}\n`;
-        const message = mergeIntoUserMessage(event.message, text);
+        const placement = readPiConfigContextPlacement({ projectDir: ctx?.cwd ?? runtime.cwd });
+        const message = mergeIntoUserMessage(event.message, text, placement);
         runtime.attachState = "sent";
         runtime.turnSelection = undefined;
         updateIdeUi(runtime, ctx);
@@ -64,10 +67,17 @@ type MergeableUserMessage = {
   content: string | UserContentBlock[];
 };
 
-function mergeIntoUserMessage<T extends MergeableUserMessage>(message: T, text: string): T {
+// Exported for tests: placement ordering is the contract the contextPlacement option controls.
+export function mergeIntoUserMessage<T extends MergeableUserMessage>(
+  message: T,
+  text: string,
+  placement: ContextPlacement = DEFAULT_CONTEXT_PLACEMENT,
+): T {
+  const block: UserContentBlock = { type: "text", text };
+  const content = normalizeUserContent(message.content);
   return {
     ...message,
-    content: [{ type: "text", text }, ...normalizeUserContent(message.content)],
+    content: placement === "append" ? [...content, block] : [block, ...content],
   };
 }
 

--- a/src/shared/config-options.ts
+++ b/src/shared/config-options.ts
@@ -58,6 +58,10 @@ export const STATUS_DISPLAY_VALUES = ["widget", "statusline"] as const;
 export type StatusDisplay = (typeof STATUS_DISPLAY_VALUES)[number];
 export const DEFAULT_STATUS_DISPLAY: StatusDisplay = "widget";
 
+export const CONTEXT_PLACEMENT_VALUES = ["prepend", "append"] as const;
+export type ContextPlacement = (typeof CONTEXT_PLACEMENT_VALUES)[number];
+export const DEFAULT_CONTEXT_PLACEMENT: ContextPlacement = "prepend";
+
 export const CONFIG_OPTIONS = {
   fixPrompt: {
     type: ["string"],
@@ -71,5 +75,12 @@ export const CONFIG_OPTIONS = {
     enum: STATUS_DISPLAY_VALUES,
     description:
       'Where to show IDE connection status. Use "widget" for the above-editor widget (default), or "statusline" for the default footer status line.',
+  },
+  contextPlacement: {
+    type: ["string"],
+    default: DEFAULT_CONTEXT_PLACEMENT,
+    enum: CONTEXT_PLACEMENT_VALUES,
+    description:
+      'Where to place the editor context system-reminder relative to your prompt. Use "prepend" to put it before your prompt text (default), or "append" to put it after so your prompt stays first in transcript views.',
   },
 } as const satisfies Record<string, ConfigOption>;

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -4,9 +4,12 @@ import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, resolve } from "node:path";
 import {
+  CONTEXT_PLACEMENT_VALUES,
+  DEFAULT_CONTEXT_PLACEMENT,
   DEFAULT_STATUS_DISPLAY,
   isConfigEnvValue,
   STATUS_DISPLAY_VALUES,
+  type ContextPlacement,
   type StatusDisplay,
 } from "./config-options.js";
 
@@ -14,12 +17,19 @@ export const EXT_CONFIG_NAME = "pi-x-ide";
 export const CONFIG_DIR_NAME = ".pi";
 export const PI_CONFIG_FILE = "config.json";
 export const STATUS_DISPLAY_CONFIG_KEY = "status_display";
+export const CONTEXT_PLACEMENT_CONFIG_KEY = "contextPlacement";
 export const AUTO_INSTALL_ENV_KEY = "PI_X_IDE_AUTO_INSTALL";
 
 export type ConfigScope = "global" | "project";
 
 export interface StatusDisplayResolution {
   value: StatusDisplay;
+  scope: ConfigScope | "default";
+  path?: string;
+}
+
+export interface ContextPlacementResolution {
+  value: ContextPlacement;
   scope: ConfigScope | "default";
   path?: string;
 }
@@ -167,6 +177,45 @@ export function resolvePiConfigStatusDisplay(
   return { value: DEFAULT_STATUS_DISPLAY, scope: "default" };
 }
 
+/**
+ * Read contextPlacement.
+ * - string path: read only that file (tests / explicit path)
+ * - options: project config overrides global; missing values fall back to default
+ */
+export function readPiConfigContextPlacement(
+  configPathOrOptions: string | { projectDir?: string; home?: string } = {},
+): ContextPlacement {
+  return resolvePiConfigContextPlacement(configPathOrOptions).value;
+}
+
+export function resolvePiConfigContextPlacement(
+  configPathOrOptions: string | { projectDir?: string; home?: string } = {},
+): ContextPlacementResolution {
+  if (typeof configPathOrOptions === "string") {
+    const value = readContextPlacementFromFile(configPathOrOptions);
+    return value === undefined
+      ? { value: DEFAULT_CONTEXT_PLACEMENT, scope: "default" }
+      : { value, scope: "global", path: configPathOrOptions };
+  }
+
+  const projectDir = configPathOrOptions.projectDir;
+  if (projectDir) {
+    const projectPath = resolvePiProjectConfigPath(projectDir);
+    const projectValue = readContextPlacementFromFile(projectPath);
+    if (projectValue !== undefined) {
+      return { value: projectValue, scope: "project", path: projectPath };
+    }
+  }
+
+  const globalPath = resolvePiGlobalConfigPath(configPathOrOptions.home);
+  const globalValue = readContextPlacementFromFile(globalPath);
+  if (globalValue !== undefined) {
+    return { value: globalValue, scope: "global", path: globalPath };
+  }
+
+  return { value: DEFAULT_CONTEXT_PLACEMENT, scope: "default" };
+}
+
 export function resolvePiConfigAutoInstall(
   configPathOrOptions: string | { projectDir?: string; home?: string } = {},
 ): AutoInstallResolution {
@@ -259,6 +308,13 @@ function readStatusDisplayFromFile(configPath: string): StatusDisplay | undefine
   return isStatusDisplay(value) ? value : undefined;
 }
 
+function readContextPlacementFromFile(configPath: string): ContextPlacement | undefined {
+  const parsed = readPiConfigFile(configPath);
+  if (!parsed || typeof parsed[CONTEXT_PLACEMENT_CONFIG_KEY] !== "string") return undefined;
+  const value = parsed[CONTEXT_PLACEMENT_CONFIG_KEY];
+  return isContextPlacement(value) ? value : undefined;
+}
+
 function readEnvValueFromFile(configPath: string, key: string): string | undefined {
   const env = readPiConfigEnv(configPath);
   return env[key];
@@ -266,6 +322,10 @@ function readEnvValueFromFile(configPath: string, key: string): string | undefin
 
 function isStatusDisplay(value: string): value is StatusDisplay {
   return (STATUS_DISPLAY_VALUES as readonly string[]).includes(value);
+}
+
+function isContextPlacement(value: string): value is ContextPlacement {
+  return (CONTEXT_PLACEMENT_VALUES as readonly string[]).includes(value);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/test/shared.test.ts
+++ b/test/shared.test.ts
@@ -8,9 +8,11 @@ import test from "node:test";
 import {
   CONFIG_DIR_NAME,
   EXT_CONFIG_NAME,
+  readPiConfigContextPlacement,
   readPiConfigEnv,
   readPiConfigFixPrompt,
   readPiConfigStatusDisplay,
+  resolvePiConfigContextPlacement,
   resolvePiConfigEnv,
   resolveIdeConfigSettings,
   resolvePiConfigAutoInstall,
@@ -46,7 +48,7 @@ import { runEffect, runEffectOrThrow, runEffectSync } from "../src/shared/effect
 import { formatExtensionError, logExtensionError, setExtensionErrorReporter } from "../src/shared/errors.js";
 import * as Effect from "effect/Effect";
 import { discoverIdeCandidates } from "../src/pi/discovery.js";
-import { clearLatestSelection, setLatestSelection } from "../src/pi/context.js";
+import { clearLatestSelection, mergeIntoUserMessage, setLatestSelection } from "../src/pi/context.js";
 import { bindPiUiContext, flushPendingPiErrors, installPiErrorReporter, notifyPiError } from "../src/pi/safety.js";
 import { createRuntime } from "../src/pi/state.js";
 import { updateIdeUi } from "../src/pi/ui.js";
@@ -117,6 +119,26 @@ void test("formats bounded editor context", () => {
   assert.match(context, /src\/main\.ts/);
   assert.match(context, /L10-L20/);
   assert.match(context, /truncated/i);
+});
+
+void test("merges editor context before the prompt by default", () => {
+  const merged = mergeIntoUserMessage({ role: "user", content: "hello" }, "<reminder>\n");
+  assert.deepEqual(merged.content, [
+    { type: "text", text: "<reminder>\n" },
+    { type: "text", text: "hello" },
+  ]);
+});
+
+void test("merges editor context after the prompt when placement is append", () => {
+  const message: { role: "user"; content: { type: "text"; text: string }[] } = {
+    role: "user",
+    content: [{ type: "text", text: "hello" }],
+  };
+  const merged = mergeIntoUserMessage(message, "<reminder>\n", "append");
+  assert.deepEqual(merged.content, [
+    { type: "text", text: "hello" },
+    { type: "text", text: "<reminder>\n" },
+  ]);
 });
 
 void test("validates selection cleared params", () => {
@@ -401,6 +423,59 @@ void test("reads status_display from pi config", async () => {
 
   await writeFile(configPath, JSON.stringify({ status_display: 1 }));
   assert.equal(readPiConfigStatusDisplay(configPath), "widget");
+});
+
+void test("reads contextPlacement from pi config", async () => {
+  const home = await mkdtemp(join(tmpdir(), "pi-x-ide-config-"));
+  const configDir = join(home, CONFIG_DIR_NAME);
+  const configPath = join(configDir, "config.json");
+  await mkdir(configDir, { recursive: true });
+
+  assert.equal(readPiConfigContextPlacement(configPath), "prepend");
+
+  await writeFile(configPath, JSON.stringify({ contextPlacement: "append" }));
+  assert.equal(readPiConfigContextPlacement(configPath), "append");
+
+  await writeFile(configPath, JSON.stringify({ contextPlacement: "prepend" }));
+  assert.equal(readPiConfigContextPlacement(configPath), "prepend");
+
+  await writeFile(configPath, JSON.stringify({ contextPlacement: "before" }));
+  assert.equal(readPiConfigContextPlacement(configPath), "prepend");
+
+  await writeFile(configPath, JSON.stringify({ contextPlacement: 1 }));
+  assert.equal(readPiConfigContextPlacement(configPath), "prepend");
+});
+
+void test("project contextPlacement overrides global config", async () => {
+  const root = await mkdtemp(join(tmpdir(), "pi-x-ide-config-scope-"));
+  const home = join(root, "home");
+  const projectDir = join(root, "project");
+  await mkdir(home, { recursive: true });
+  await mkdir(projectDir, { recursive: true });
+
+  const globalPath = join(home, CONFIG_DIR_NAME, EXT_CONFIG_NAME, "config.json");
+  await mkdir(dirname(globalPath), { recursive: true });
+  await writeFile(globalPath, JSON.stringify({ contextPlacement: "prepend" }));
+
+  assert.deepEqual(resolvePiConfigContextPlacement({ projectDir, home }), {
+    value: "prepend",
+    scope: "global",
+    path: globalPath,
+  });
+
+  const projectPath = join(projectDir, CONFIG_DIR_NAME, EXT_CONFIG_NAME, "config.json");
+  await mkdir(dirname(projectPath), { recursive: true });
+  await writeFile(projectPath, JSON.stringify({ contextPlacement: "append" }));
+  assert.equal(readPiConfigContextPlacement({ projectDir, home }), "append");
+  assert.deepEqual(resolvePiConfigContextPlacement({ projectDir, home }), {
+    value: "append",
+    scope: "project",
+    path: projectPath,
+  });
+
+  // Invalid project values fall through to the global file.
+  await writeFile(projectPath, JSON.stringify({ contextPlacement: "middle" }));
+  assert.equal(readPiConfigContextPlacement({ projectDir, home }), "prepend");
 });
 
 void test("project status_display overrides global config", async () => {


### PR DESCRIPTION
## Summary

The editor context `<system-reminder>` is always merged as the **first** content block of the user prompt (`mergeIntoUserMessage` in `src/pi/context.ts`). In transcript views such as Pi's `/tree`, every user message therefore starts with the reminder text, which makes it hard to visually distinguish the user's actual input.

This adds a top-level `contextPlacement` config option for `~/.pi/pi-x-ide/config.json`:

```json
{
  "contextPlacement": "append"
}
```

- `"prepend"` (default) — current behavior, reminder placed before the prompt text
- `"append"` — reminder placed after the prompt text, so the user's prompt stays first in transcript views while the model still receives the context

The option follows the same resolution chain as `status_display` (project config overrides global, invalid values fall back to the default) and is read at injection time, matching how other config options are consumed. It is registered in `CONFIG_OPTIONS` and picked up by the generated `schemas/config.json`.

## Changes

- `src/shared/config-options.ts` — `contextPlacement` registry entry + `ContextPlacement` type/values
- `src/shared/config.ts` — `readPiConfigContextPlacement` / `resolvePiConfigContextPlacement` (mirrors `status_display` resolution)
- `src/pi/context.ts` — merge honors the placement; default via `DEFAULT_CONTEXT_PLACEMENT`
- `schemas/config.json` — regenerated with `generate-config-schema.cjs` (verified with `--check`)
- `config.example.json`, `docs/reference/configuration.md`, `docs/zh-CN/reference/configuration.md` — docs parity (en + zh-CN)
- `test/shared.test.ts` — tests for config resolution (defaults, invalid values, project override) and merge ordering for both placements

## Testing

- `tsgo --noEmit` typecheck passes
- `eslint` clean on touched files
- `generate-config-schema.cjs --check` passes
- `test/shared.test.ts`: 54/54 pass (4 new tests)
- Full suite: no regressions — the 12 failing entry-build tests fail identically on a clean `main` checkout in this environment (verified via `git stash`), unrelated to this change